### PR TITLE
Update Bender dependencies

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -2,8 +2,8 @@ package:
   name: axi2mem
 
 dependencies:
-  common_cells: { git: "git@iis-git.ee.ethz.ch:sasa/common_cells.git", version: 1.2.2 }
-  axi_slice: { git: "git@iis-git.ee.ethz.ch:sasa/axi_slice.git", version: 1.1.2 }
+  common_cells: { git: "git@github.com:pulp-platform/common_cells.git", version: 1.13.1 }
+  axi_slice: { git: "git@github.com:pulp-platform/axi_slice.git", version: 1.1.4 }
 
 sources:
   - axi2mem_busy_unit.sv


### PR DESCRIPTION
This repository is deprecated, but still used in https://github.com/pulp-platform/pulp_cluster . 